### PR TITLE
added error boundaries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "firebase": "^10.6.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-error-boundary": "^5.0.0",
         "react-firebase-hooks": "^5.1.1",
         "react-router-dom": "^6.17.0",
         "react-scripts": "5.0.1",
@@ -15748,6 +15749,18 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-error-boundary": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-5.0.0.tgz",
+      "integrity": "sha512-tnjAxG+IkpLephNcePNA7v6F/QpWLH8He65+DmedchDwg162JZqx4NmbXj0mlAYVVEd81OW7aFhmbsScYfiAFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
       }
     },
     "node_modules/react-error-overlay": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "firebase": "^10.6.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-error-boundary": "^5.0.0",
     "react-firebase-hooks": "^5.1.1",
     "react-router-dom": "^6.17.0",
     "react-scripts": "5.0.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,16 +1,20 @@
 import { Suspense } from 'react';
+import { ErrorBoundary } from "react-error-boundary";
 import { BrowserRouter } from 'react-router-dom';
 import MainLayout from './MainLayout';
 import LoadingComponent from './components/LoadingComponent';
 import StickyHeader from './components/StickyHeader'
+import ErrorMessage from './ErrorMessage';
 
 function App() {
   return (
     <BrowserRouter>
       <StickyHeader />
-      <Suspense fallback={<LoadingComponent />}>
-        <MainLayout />
-      </Suspense>
+      <ErrorBoundary fallbackRender={ErrorMessage}>
+        <Suspense fallback={<LoadingComponent />}>
+          <MainLayout />
+        </Suspense>
+      </ErrorBoundary>
     </BrowserRouter>
   );
 }

--- a/src/ErrorMessage.jsx
+++ b/src/ErrorMessage.jsx
@@ -1,0 +1,14 @@
+import CommonContainer from "./components/CommonContainer";
+
+const ErrorMessage = ({ error, resetErrorBoundary }) => {
+  return (
+    <CommonContainer>
+      <h2 className="text-center">Algo salió mal:</h2>
+      <p>Muestre el siguiente mensaje a los administradores del sitio:</p>
+      <code className="error">{error.message}</code>
+      <button className="mt-3 text-center" onClick={resetErrorBoundary}>Recargar la página</button>
+    </CommonContainer>
+  );
+}
+
+export default ErrorMessage;

--- a/src/index.css
+++ b/src/index.css
@@ -23,3 +23,12 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+.error {
+  font-size: 0.7rem;
+  display: block;
+  padding: 20px;
+  border-radius: 12px;
+  background-color: pink;
+  color: red;
+}


### PR DESCRIPTION
This is how it will look the error boundary. If anything fails, instead of a white screen, it'll show this

![image](https://github.com/user-attachments/assets/1b8fefe7-e1e0-4cfc-bda8-47f94a5c04ea)
